### PR TITLE
Adding u'Plex' to APP_WHITELIST

### DIFF
--- a/lastcast/__init__.py
+++ b/lastcast/__init__.py
@@ -11,7 +11,7 @@ import toml
 
 
 # TODO: ...and probably other things...
-APP_WHITELIST = [u'Spotify', u'Google Play Music']
+APP_WHITELIST = [u'Spotify', u'Google Play Music', u'Plex']
 SCROBBLE_THRESHOLD_PCT = 0.50
 SCROBBLE_THRESHOLD_SECS = 120
 


### PR DESCRIPTION
Plex media server provides all required metadata fields used by lastcast for LastFM scrobbling. This change adds Plex to the app whitelist.

```
In [1]: import pychromecast
In [2]: cast = pychromecast.get_chromecast(friendly_name='Soundfactory')
In [3]: status = cast.media_controller.status
In [4]: status.player_is_playing
Out[4]: True

In [5]: status.current_time
Out[5]: 74.745

In [6]: status.duration
Out[6]: 351.791

In [7]: status.artist
Out[7]: u'Blunted Dummies'

In [8]: status.album_name
Out[8]: u'House for All VLS'

In [9]: status.title
Out[9]: u'House For All (Robots Mix)'

In [10]: status
Out[10]: <MediaStatus {'player_state': u'PLAYING', 'volume_level': 1, 'images': [], 'media_custom_data': {u'showLoading': True, u'errorMessage': None, u'key': u'/library/metadata/6684', u'directPlay': True, u'audioStreamID': 10893, u'audioBoost': 100, u'transcodeServerID': u'3baca653e1d9e4c231e5aebc45235e8d4737c118', u'subtitleStreamID': 0, u'server': {u'myPlexSubscription': False, u'protocol': u'http', u'transcoderAudio': True, u'transcoderVideo': True, u'address': u'10.0.0.200', u'isVerifiedHostname': False, u'version': u'1.1.4.2757', u'transcoderVideoRemuxOnly': False, u'machineIdentifier': u'3baca653e1d9e4c231e5aebc45235e8d4737c118', u'port': u'32400'}, u'partIndex': 0, u'subtitleSize': 100, u'user': {}, u'containerKey': u'/playQueues/28?own=1&window=200', u'offset': 96.306, u'needsPlayQueue': True, u'mediaIndex': 0, u'autoplay': True, u'type': u'music', u'directStream': True}, 'duration': 351.791, 'current_time': 74.745, 'playback_rate': 1, 'title': u'House For All (Robots Mix)', 'media_session_id': 4, 'volume_muted': False, 'supports_skip_forward': False, 'track': None, 'season': None, 'idle_reason': None, 'stream_type': u'BUFFERED', 'supports_stream_mute': True, 'supports_stream_volume': True, 'content_type': u'music', 'metadata_type': 3, 'subtitle_tracks': {}, 'album_name': u'House for All VLS', 'series_title': None, 'album_artist': u'Blunted Dummies', 'media_metadata': {u'metadataType': 3, u'artist': u'Blunted Dummies', u'title': u'House For All (Robots Mix)', u'albumName': u'House for All VLS', u'albumArtist': u'Blunted Dummies', u'trackNumber': 2, u'discNumber': 1}, 'episode': None, 'artist': u'Blunted Dummies', 'supported_media_commands': 15, 'supports_seek': True, 'content_id': u'/library/metadata/6684', 'supports_skip_backward': False, 'supports_pause': True}>

In [15]: cast.app_display_name
Out[15]: u'Plex'
```