### PR TITLE
use album artist for tracks with no artist metadata

### DIFF
--- a/lastcast/__init__.py
+++ b/lastcast/__init__.py
@@ -110,7 +110,7 @@ class ScrobbleListener(object):
 
     def _on_status(self, status):
         meta = {
-            'artist': status.artist,
+            'artist': status.artist if status.artist else status.album_artist,
             'album': status.album_name,
             'title': status.title,
         }


### PR DESCRIPTION
For some reason the `status.artist` field is always empty when I'm using Google Play Music and this prevents proper scrobbling. 

This change will use the `album_artist` field if `artist` is empty. 