### PR TITLE
prevent empty strings from accidentally showing up in app_whitelist

### DIFF
--- a/lastcast/__init__.py
+++ b/lastcast/__init__.py
@@ -189,8 +189,9 @@ Key and Shared Secret.
                ', '.join(APP_WHITELIST))
 
     apps = click.prompt('Comma separated apps [blank for default]')
+    apps = [app.strip() for app in apps.split(',') if app.strip() != ""]
+
     if apps:
-        apps = [app.strip() for app in apps.split(',')]
         config['chromecast']['app_whitelist'] = apps
 
     generated = toml.dumps(config)


### PR DESCRIPTION
Got an email earlier from someone who had this in their config:

```
app_whitelist = ["", ]
```

The wizard should be smart enough to prevent this.