### PR TITLE
Add YouTube Music to app whitelist

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ lastcast
 Scrobble music playing on Chromecast devices to last.fm and libre.fm.
 
 By default, lastcast will scrobble music playing on Spotify,
-Google Play Music, SoundCloud, and Plex, but can be configured to
-scrobble any media player that supports Chromecast.
+Google Play Music, SoundCloud, Plex, and YouTube Music but can
+be configured to scrobble any media player that supports Chromecast.
 
 **A Note for Spotify Users:**
 

--- a/lastcast/__init__.py
+++ b/lastcast/__init__.py
@@ -14,7 +14,7 @@ import toml
 logger = logging.getLogger(__name__)
 
 # Default set of apps to scrobble from.
-APP_WHITELIST = ['Spotify', 'Google Play Music', 'SoundCloud', 'Plex']
+APP_WHITELIST = ['Spotify', 'Google Play Music', 'SoundCloud', 'Plex', 'YouTube Music']
 
 SCROBBLE_THRESHOLD_PCT = 0.50
 SCROBBLE_THRESHOLD_SECS = 120


### PR DESCRIPTION
Hi there, I tried to enable YouTube Music by adding it to the whitelist and it seems to be working, would you mind merging this in?

```
>>> import pychromecast
>>> chromecasts = pychromecast.get_chromecasts()
>>> cast = next(cc for cc in chromecasts if cc.device.friendly_name == "Everywhere")
>>> status = cast.media_controller.status
>>> status.artist
'The Gathering'
>>> status.title
'Leaves (Live)'
>>> status.album_name
'Mandylion'
>>> status.current_time
5
>>> status.duration
361
>>> cast.app_display_name
'YouTube Music'
```

```
aybara:lastcast mone$ lastcast
Using chromecast: Everywhere
Scrobbling: The Gathering - Leaves (Live) [Mandylion]
Scrobbling: Lacuna Coil - Enjoy The Silence [Karmacode]
```