### PR TITLE
update pychromecast to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'PyChromecast==2.0.0',
+        'PyChromecast==5.3.0',
         'click==6.7',
         'pylast==1.7.0',
         'toml==0.9.4',


### PR DESCRIPTION
Uses latest version of pychromecast to allow lastcast to work in lxc container.  Related to https://github.com/erik/lastcast/issues/53