### PR TITLE
Add __main__.py entrypoint

### DIFF
--- a/lastcast/__init__.py
+++ b/lastcast/__init__.py
@@ -416,6 +416,3 @@ def main(config, wizard, verbose):
 
         time.sleep(POLL_INTERVAL)
 
-
-if __name__ == '__main__':
-    main()

--- a/lastcast/__main__.py
+++ b/lastcast/__main__.py
@@ -1,0 +1,6 @@
+from lastcast import main
+
+
+if __name__ == '__main__':
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -12,14 +12,14 @@ if sys.version_info < (3, 6):
 
 setup(
     name='lastcast',
-    version='2.0.0',
+    version='2.0.1',
     description='Scrobble music to last.fm from Chromecast.',
     author='Erik Price',
     url='https://github.com/erik/lastcast',
     packages=['lastcast'],
     entry_points={
         'console_scripts': [
-            'lastcast = lastcast:main',
+            'lastcast = lastcast.__main__:main',
         ],
     },
     license='MIT',


### PR DESCRIPTION
This allows lastcast to be run via `python -m lastcast`, and should be
more straightforward for Windows users.

Resolves #55.