### PR TITLE
Bump dependencies to be compatible with more recent versions of Python.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,10 @@ import sys
 from setuptools import setup
 
 
-# Be verbose about Python < 3.6 being deprecated.
-if sys.version_info < (3, 6):
+# Be verbose about Python < 3.7 being deprecated.
+if sys.version_info < (3, 7):
     print('\n' * 3 + '*' * 64)
-    print('lastcast requires Python 3.6+, and might be broken if run with\n'
+    print('lastcast requires Python 3.7+, and might be broken if run with\n'
           'this version of Python.')
     print('*' * 64 + '\n' * 3)
 

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,8 @@ setup(
     ],
     install_requires=[
         'PyChromecast==12.1.4',
-        'click==6.7',
-        'pylast==1.7.0',
-        'toml==0.9.4',
+        'click==8.1.3',
+        'pylast==5.0.0',
+        'toml==0.10.2',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        'PyChromecast==5.3.0',
+        'PyChromecast==12.1.4',
         'click==6.7',
         'pylast==1.7.0',
         'toml==0.9.4',


### PR DESCRIPTION
The 5.3.0 version of PyChromecast is relying on some methods that were removed in 3.9, and newer versions fix this, although some fields were also renamed. This just bumps some packages and updates things to match correspondingly. Things seem to be working just fine under 3.10.